### PR TITLE
Iterating on the API

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,5 @@
 import BuildHelper._
+import com.github.sbt.jni.build.Cargo
 
 inThisBuild(
   List(
@@ -52,7 +53,10 @@ lazy val zioUring = project
 
 lazy val zioUringRs = project
   .in(file("zio-uring-rs"))
-  .settings(nativeCompile / sourceDirectory := baseDirectory.value)
+  .settings(
+    nativeCompile / sourceDirectory := baseDirectory.value,
+    // nativeBuildTool := Cargo.make(release = false)
+  )
   .enablePlugins(JniNative)
 
 lazy val zioUringNative = project

--- a/zio-uring-rs/src/lib.rs
+++ b/zio-uring-rs/src/lib.rs
@@ -18,9 +18,7 @@ pub unsafe extern "system" fn Java_zio_uring_native_Native_initRing(
 ) -> jlong {
     // let uring = IoUring::builder().setup_iopoll().build(entries as _).unwrap();
     let uring = IoUring::new(entries as _).unwrap();
-    let ptr = Box::into_raw(Box::new(uring)) as jlong;
-    println!("Opened ring {}", ptr);
-    ptr
+    Box::into_raw(Box::new(uring)) as jlong
 }
 
 #[no_mangle]
@@ -90,8 +88,6 @@ pub unsafe extern "system" fn Java_zio_uring_native_Native_write(
     ioLinked: jboolean,
 ) -> () {
     let uring: &mut IoUring = &mut *(ringPtr as *mut IoUring);
-
-    println!("Writing to file descriptor {}", fd);
 
     let buf: &mut [u8] = env.get_direct_buffer_address(buffer).unwrap();
     let length = env.get_direct_buffer_capacity(buffer).unwrap() as u32;

--- a/zio-uring-rs/src/lib.rs
+++ b/zio-uring-rs/src/lib.rs
@@ -131,7 +131,6 @@ pub unsafe extern "system" fn Java_zio_uring_native_Native_peek(
 
     while count_inner < count && !cq.is_empty() {
         let cqe = cq.next().unwrap();
-        cq.sync();
         let ud_as_bytes: [u8; 8] = transmute(cqe.user_data().to_be());
         for b in ud_as_bytes {
             buf[buf_offset] = b;

--- a/zio-uring/src/main/scala/Native.scala
+++ b/zio-uring/src/main/scala/Native.scala
@@ -9,9 +9,9 @@ class Native {
 
   @native def destroyRing(ringPtr: Long): Unit
 
-  @native def read(ringPtr: Long, reqId: Long, fd: Int, offset: Long, buffer: ByteBuffer): Unit
+  @native def read(ringPtr: Long, reqId: Long, fd: Int, offset: Long, buffer: ByteBuffer, ioLinked: Boolean): Unit
 
-  @native def write(ringPtr: Long, reqId: Long, fd: Int, offset: Long, data: ByteBuffer): Unit
+  @native def write(ringPtr: Long, reqId: Long, fd: Int, offset: Long, data: ByteBuffer, ioLinked: Boolean): Unit
 
   @native def submit(ringPtr: Long): Unit
 
@@ -20,4 +20,11 @@ class Native {
   @native def await(ringPtr: Long, count: Int, buffer: ByteBuffer): Unit
 
   @native def openFile(ringPtr: Long, reqId: Long, path: String): Unit
+
+  @native def cancel(ringPtr: Long, reqId: Long, opReqId: Long): Unit
+
+  @native def send(ringPtr: Long, reqId: Long, socketFd: Int, data: ByteBuffer): Unit
+
+  @native def receive(ringPtr: Long, reqId: Long, socketFd: Int, buffer: ByteBuffer): Unit
+
 }

--- a/zio-uring/src/main/scala/Ring.scala
+++ b/zio-uring/src/main/scala/Ring.scala
@@ -87,6 +87,8 @@ class Ring(native: Native, ringFd: Long, completionsChunkSize: Int) {
         case Callback.Read(buf, cb) if retCode < 0  => cb(Left(retCode))
         case c @ Callback.Write(cb)                 => cb(retCode)
         case c @ Callback.OpenFile(cb)              => cb(retCode)
+        // Ignore operations cancelled after completion
+        case Callback.Cancelled                     => ()
         // Need a better way to know when we've read everything....
         case null                                   => run = false //sys.error(s"Oops: nonexistent request $reqId completed")
       }
@@ -96,7 +98,10 @@ class Ring(native: Native, ringFd: Long, completionsChunkSize: Int) {
   def cancel(requestId: Long): Unit =
     if (!shutdown.get()) {
       val reqId = requestIds.getAndIncrement()
-      pendingReqs.remove(requestId) match {
+      // If the request is still pending completion replace the callback with a NOP
+      // since we cannot guarantee the cancellation will happen before the existing
+      // operation is cancelled 
+      pendingReqs.replace(requestId, Callback.Cancelled) match {
         case null => ()
         case c    => native.cancel(ringFd, reqId, requestId)
       }
@@ -121,4 +126,5 @@ object Callback {
   case class Read(buf: ByteBuffer, cb: Either[Int, Chunk[Byte]] => Unit) extends Callback
   case class Write(cb: Int => Unit)                                      extends Callback
   case class OpenFile(cb: Int => Unit)                                   extends Callback
+  case object Cancelled                                                  extends Callback
 }

--- a/zio-uring/src/main/scala/RingIO.scala
+++ b/zio-uring/src/main/scala/RingIO.scala
@@ -73,7 +73,7 @@ object RingIO {
     } yield (ring, poller)
 
     effect.toManaged { case (ring, poller) =>
-      shutdown.set(true)
+      UIO(shutdown.set(true)) *>
       poller.await *> ring.close().orDie
     }.map(_._1)
   }

--- a/zio-uring/src/main/scala/Uring.scala
+++ b/zio-uring/src/main/scala/Uring.scala
@@ -15,11 +15,10 @@ object Uring extends App {
           fd           <- ring.open(tempFile.toString)
           _            <- ring.open("not-a-file").catchAll(ioe => putStrLn(s"File open failed with message: ${ioe.getMessage()}"))
           _            <- putStrLn(s"Opened $fd")
-          write1       <- ring.write(fd, 0, "foobar".getBytes(), false).fork
+          bytesWritten <- ring.write(fd, 0, "foobar".getBytes(), false)
+          _            <- putStrLn(s"Wrote $bytesWritten bytes to $fd")
           read1        <- ring.read(fd, 0, 1024, true).fork
           read2        <- ring.read(fd, 0, 1024, false).fork
-          bytesWritten <- write1.join
-          _            <- putStrLn(s"Wrote $bytesWritten bytes to $fd")
           data1        <- read1.join
           data2        <- read2.join
           _            <- putStrLn(s"Read:\n${new String(data1.toArray[Byte], "UTF-8")}")

--- a/zio-uring/src/main/scala/Uring.scala
+++ b/zio-uring/src/main/scala/Uring.scala
@@ -2,39 +2,30 @@ package zio.uring
 
 import zio._
 import zio.console._
-import zio.internal.Platform
-import zio.internal.Executor
-import java.util.concurrent.Executors
-import java.util.concurrent.ThreadPoolExecutor
+import java.nio.file.Files
 
 object Uring extends App {
 
-  override def platform: Platform = Platform.default.withExecutor(
-    Executor.fromThreadPoolExecutor(_ => 24)(Executors.newFixedThreadPool(1).asInstanceOf[ThreadPoolExecutor])
-  )
-
   override def run(args: List[String]): URIO[ZEnv, ExitCode] =
     RingIO
-      .make(128, 32)
-      .toManaged(_.close().orDie)
+      .managed(128, 32)
       .use { ring =>
         for {
-          poll  <- ring.poll().forever.forkDaemon
-          o     <- ring.open("/etc/passwd").fork
-          // _     <- ring.submit()
-          fd    <- o.join
-          _     <- putStrLn(s"Opened $fd")
-          read1 <- ring.read(fd, 0, 1024).fork
-          read2 <- ring.read(fd, 0, 1024).fork
-          // _     <- ring.submit()
-          data1 <- read1.join
-          data2 <- read2.join
-          _     <- putStrLn(s"Read:\n${new String(data1.toArray[Byte], "UTF-8")}")
-          _     <- putStrLn(s"Read:\n${new String(data2.toArray[Byte], "UTF-8")}")
-          _     <- poll.interrupt
-          _     <- getStrLn
+          tempFile     <- IO.effectTotal(Files.createTempFile("temp", ".txt"))
+          fd           <- ring.open(tempFile.toString)
+          _            <- ring.open("not-a-file").catchAll(ioe => putStrLn(s"File open failed with message: ${ioe.getMessage()}"))
+          _            <- putStrLn(s"Opened $fd")
+          write1       <- ring.write(fd, 0, "foobar".getBytes(), false).fork
+          read1        <- ring.read(fd, 0, 1024, true).fork
+          read2        <- ring.read(fd, 0, 1024, false).fork
+          bytesWritten <- write1.join
+          _            <- putStrLn(s"Wrote $bytesWritten bytes to $fd")
+          data1        <- read1.join
+          data2        <- read2.join
+          _            <- putStrLn(s"Read:\n${new String(data1.toArray[Byte], "UTF-8")}")
+          _            <- putStrLn(s"Read:\n${new String(data2.toArray[Byte], "UTF-8")}")
         } yield ()
-
       }
+      .catchAll(e => putStrLn(s"IOException: ${e.getMessage}"))
       .exitCode
 }


### PR DESCRIPTION
Adding some polish:

1. Error handling when the completion event returns an error (when retCode < 0)
2. Helper to create `RingIO` as a `Managed` which handles polleng automatically. For this I needed to introduce some extra machinery to signal a shutdown otherwise the polling fiber will keep running after shutdown and segfault.
3. Add flags to setting the `IoLink` flag on submission queue events. This will allow you to specify ordering on events processed by the kernel. It doesn't quite work the way I would expect right now so need to figure some things out there. 
4. Propagate effect cancellations to the kernel.

This should be more-or-less usable without the specialized executor but still need to think about how we expose the API so you can use it either way somewhat straightforwardly. 

The other question I have is whether we expose linking to the Scala API or whether we can get by just inserting "barriers." I **think** we can just submit a `NOP` operation with the `IO_DRAIN` flag set and it will create a processing barrier where everything before will be processed by the kernel before anything after is processed. It's a little hard to make the API work in sensible ways if we aren't making fairly strong assumptions about concurrency (will events be submitted from multiple threads?). If we really want to make it general purpose we may need to handle queueing on the JVM side so we can guarantee  submission ordering.  